### PR TITLE
Add complementary pair suggestions

### DIFF
--- a/data/product_category_map.csv
+++ b/data/product_category_map.csv
@@ -1,0 +1,17 @@
+Product_Name,Category,Current_Zone
+Corn Flakes 500g,Cereal,J4
+Amul Milk 1L Pouch,Milk,I4
+Dove Shampoo 180ml,Shampoo,C6
+Pantene Conditioner 180ml,Conditioner,D5
+Lays Chips Family,Chips,F9
+Pepsi 1.5L,Cold Drinks,H1
+Close-up Toothpaste Gel,Toothpaste,H9
+Oral-B Toothbrush,Toothbrush,H4
+Bread Loaf Brown,Bread,D6
+Amul Butter 500g,Butter/Jam,C4
+KitKat Chocolate Bar,Chocolates,E8
+Barbie Doll,Gifting Items,G5
+Maggi Noodles 6-Pack,Maggi,J5
+Tomato Ketchup 500g,Tomato Ketchup,F8
+Sunfeast Yippee Noodles,Pasta,F6
+Pasta Sauce 500g,Pasta Sauce,F7

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ from heatsight_tools import (
     get_declining_products,
     compare_dwell_time,
     get_complementary_products,
+    suggest_complementary_pairs,
     get_top_footfall_zones,
     get_low_conversion_hot_zones,
     get_products_to_relocate,
@@ -418,6 +419,7 @@ with tab6:
         get_declining_products,
         compare_dwell_time,
         get_complementary_products,
+        suggest_complementary_pairs,
         get_top_footfall_zones,
         get_low_conversion_hot_zones,
         get_products_to_relocate,
@@ -442,7 +444,8 @@ with tab6:
                     "system",
                     "You are ShelfSense AI, a retail optimization copilot. "
                     "You help analyze shelf performance, recommend product relocations, simulate changes, and give business insights across footfall, POS sales, and online interest. "
-                    "You have access to memory, real-time data files, and tools to analyze store layout and behavior."
+                    "You have access to memory, real-time data files, and tools to analyze store layout and behavior. "
+                    "You can use category-level complementary logic to enhance placement strategy."
                 ),
                 MessagesPlaceholder(variable_name="chat_history"),
                 ("human", "{input}"),


### PR DESCRIPTION
## Summary
- create `product_category_map.csv` with product categories and zones
- add `PRODUCT_CATEGORY_MAP_PATH` constant
- implement `suggest_complementary_pairs` tool using complementary rules
- register new tool and mention complementary logic in system prompt

## Testing
- `python -m py_compile heatsight_tools.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6874a9419ed48320af46d8cee1977497