### PR TITLE
Add relocation history memory to ShelfSense

### DIFF
--- a/agent_memory/decision_log.json
+++ b/agent_memory/decision_log.json
@@ -1,0 +1,30 @@
+[
+  {
+    "product_name": "Toothpaste",
+    "old_zone": "D4",
+    "new_zone": "B2",
+    "date": "2025-07-10",
+    "outcome_description": "Sales increased by 12% after relocation"
+  },
+  {
+    "product_name": "Detergent",
+    "old_zone": "C2",
+    "new_zone": "A1",
+    "date": "2025-07-07",
+    "outcome_description": "Sales dropped 8%, low visibility – avoid A1"
+  },
+  {
+    "product_name": "Protein Bars",
+    "old_zone": "D3",
+    "new_zone": "B1",
+    "date": "2025-07-05",
+    "outcome_description": "Sales increased 18%, good match with Gym Supplements nearby"
+  },
+  {
+    "product_name": "Chocolate Gift Pack",
+    "old_zone": "F5",
+    "new_zone": "Checkout",
+    "date": "2025-07-04",
+    "outcome_description": "Festival sales boosted by 30% – great festive spot"
+  }
+]

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ from heatsight_tools import (
     get_top_footfall_zones,
     get_low_conversion_hot_zones,
     get_products_to_relocate,
+    get_past_relocation_outcomes,
     get_relocation_reason,
     simulate_relocation_swap,
     get_high_online_low_pos_products,
@@ -440,6 +441,7 @@ with tab6:
         get_top_footfall_zones,
         get_low_conversion_hot_zones,
         get_products_to_relocate,
+        get_past_relocation_outcomes,
         get_relocation_reason,
         simulate_relocation_swap,
         get_high_online_low_pos_products,
@@ -475,6 +477,7 @@ with tab6:
                     "You are ShelfSense AI, a retail optimization copilot. "
                     "You help analyze shelf performance, recommend product relocations, simulate changes, and give business insights across footfall, POS sales, and online interest. "
                     "You have access to memory, real-time data files, and tools to analyze store layout and behavior. "
+                    "Use the get_past_relocation_outcomes tool whenever a user asks about prior moves or relocation history. "
                     "You can use category-level complementary logic to enhance placement strategy."
                 ),
                 MessagesPlaceholder(variable_name="chat_history"),


### PR DESCRIPTION
## Summary
- introduce `decision_log.json` storing sample relocation history
- enhance relocation logging with `date` field
- allow retrieving past outcomes filtered by product or zone
- expose history tool in ShelfSense copilot and update system prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874cb67ddf483209dc834eb1c26ce6e